### PR TITLE
Added babel-core as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "ISC",
   "dependencies": {},
   "devDependencies": {
+    "babel-core": "^6.18.2",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",


### PR DESCRIPTION
Webpack won't be able to run babel-loader without babel-core. 